### PR TITLE
Update Make File to only add LIBS at end

### DIFF
--- a/asteroids/makefile
+++ b/asteroids/makefile
@@ -27,7 +27,7 @@ DEPS = $(OBJS:%.o=%.d)
 
 # Recipe for generating objects into build
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp
-	$(CC) $(CFLAGS) -c $< -o $@ $(LIBS)
+	$(CC) $(CFLAGS) -c $< -o $@
 
 # Generate executable, 
 # use @ variable to compile to target executable from build dir objects


### PR DESCRIPTION
Updated make file so that Libraries are statically added to executable at the end (not when each source file is compiled)